### PR TITLE
[CHANGE] use of UIScreenEdgePanGestureRecognizer instead of UIPanGestureRecognizer for drag pop gesture

### DIFF
--- a/RainbowNavigation/RainbowDragPop.swift
+++ b/RainbowNavigation/RainbowDragPop.swift
@@ -11,8 +11,8 @@ class RainbowDragPop: UIPercentDrivenInteractiveTransition {
     var interacting = false
     weak var navigationController:UINavigationController! {
         didSet {
-            let panGesture = UIPanGestureRecognizer(target: self, action: #selector(RainbowDragPop.handlePan(_:)))
-            
+            let panGesture   = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(RainbowDragPop.handlePan(_:)))
+            panGesture.edges = UIRectEdge.left
             navigationController?.view.addGestureRecognizer(panGesture)
         }
     }
@@ -27,7 +27,7 @@ class RainbowDragPop: UIPercentDrivenInteractiveTransition {
     }
     
     
-    func handlePan(_ panGesture:UIPanGestureRecognizer) {
+    func handlePan(_ panGesture:UIScreenEdgePanGestureRecognizer) {
         let offset = panGesture.translation(in: panGesture.view)
         let velocity = panGesture.velocity(in: panGesture.view)
         


### PR DESCRIPTION
This change limits the position of the drag to pop gesture to the left edge of the screen, similar to the native back swipe gesture. Also other pan gestures can be added to the view without being cancelled by the RainbowDragPop gesture.